### PR TITLE
Deprecate all configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,8 +2,10 @@
 
 namespace Yokai\EnumBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * @author Yann Eugoné <eugone.yann@gmail.com>
@@ -15,8 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('yokai_enum');
+        if (version_compare(Kernel::VERSION, '4.2') >= 0) {
+            $treeBuilder = new TreeBuilder('presta_sitemap');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('presta_sitemap');
+        }
 
         $rootNode
             ->children()
@@ -25,11 +32,11 @@ class Configuration implements ConfigurationInterface
                     ->defaultFalse()
                 ->end()
                 ->booleanNode('enum_autoconfiguration')
-                    ->info('If set to true, all services that implements EnumInterface, will obtain the "enum" tag automatically.')
+                    ->info('[DEPRECATED] If set to true, all services that implements EnumInterface, will obtain the "enum" tag automatically.')
                     ->defaultTrue()
                 ->end()
                 ->booleanNode('enum_registry_autoconfigurable')
-                    ->info('If set to true, add an alias for the enum registry so your service can ask for it via autoconfiguration.')
+                    ->info('[DEPRECATED] If set to true, add an alias for the enum registry so your service can ask for it via autoconfiguration.')
                     ->defaultTrue()
                 ->end()
             ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,11 +18,11 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         if (version_compare(Kernel::VERSION, '4.2') >= 0) {
-            $treeBuilder = new TreeBuilder('presta_sitemap');
+            $treeBuilder = new TreeBuilder('yokai_enum');
             $rootNode = $treeBuilder->getRootNode();
         } else {
             $treeBuilder = new TreeBuilder();
-            $rootNode = $treeBuilder->root('presta_sitemap');
+            $rootNode = $treeBuilder->root('yokai_enum');
         }
 
         $rootNode

--- a/DependencyInjection/EnumExtension.php
+++ b/DependencyInjection/EnumExtension.php
@@ -22,6 +22,16 @@ class EnumExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        if ($config['register_bundles']) {
+            @trigger_error('"register_bundles" config var with value "true" is deprecated since v2.3 and will be removed in v3.0', \E_USER_DEPRECATED);
+        }
+        if (!$config['enum_autoconfiguration']) {
+            @trigger_error('"enum_autoconfiguration" config var with value "false" is deprecated since v2.3 and will be removed in v3.0', \E_USER_DEPRECATED);
+        }
+        if ($config['enum_registry_autoconfigurable']) {
+            @trigger_error('"enum_registry_autoconfigurable" config var with value "false" is deprecated since v2.3 and will be removed in v3.0', \E_USER_DEPRECATED);
+        }
+
         $container->setParameter('enum.register_bundles', $config['register_bundles']);
 
         $xmlLoader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));


### PR DESCRIPTION
These configuration will be dropped as of 3.x.

We will always :
- register enum registry FQCN alias
- autoconfigure services implementing EnumInterface with enum tag 
