### PR TITLE
Make ConstantExtractor a static class to easy enum autowiring

### DIFF
--- a/doc/declaring-enum.md
+++ b/doc/declaring-enum.md
@@ -8,6 +8,16 @@ There is a lot of way to create and declare such classes.
 > **Note :** If you wish to declare translation based enum, 
 > please see [dedicated documentation](declaring-translated-enum.md)
 
+Services declarations assume that your services files has the following defaults section :
+
+```yaml
+services:
+    _defaults:
+        public: false
+        autowire: true
+        autconfigure: true
+```
+
 
 The classic way
 ---------------
@@ -35,14 +45,11 @@ class GenderEnum implements EnumInterface
 }
 ```
 
-Define an enum service for it.
+Define an enum service for it (optional if you are using the default Symfony services file).
 
 ```yaml
 services:
-    enum.member.gender:
-        class: 'App\Enum\GenderEnum'
-        public: false
-        tags: ['enum']
+    App\Enum\GenderEnum: ~
 ```
 
 
@@ -70,14 +77,11 @@ class GenderEnum implements EnumInterface
 }
 ```
 
-Define an enum service for it.
+Define an enum service for it (optional if you are using the default Symfony services file).
 
 ```yaml
 services:
-    enum.member.gender:
-        class: 'App\Enum\GenderEnum'
-        public: false
-        tags: ['enum']
+    App\Enum\GenderEnum: ~
 ```
 
 
@@ -89,13 +93,12 @@ No need for a class, just use the `ConfigurableEnum` class and define a new enum
 ```yaml
 services:
     enum.member.gender:
-        class: 'Yokai\EnumBundle\ConfigurableEnum'
-        public: false
-        tags: ['enum']
+        class: Yokai\EnumBundle\ConfigurableEnum
         arguments:
-            - "gender"
-            - m: 'Male'
-              f: 'Female'
+            $name: 'gender'
+            $choices: 
+                m: 'Male'
+                f: 'Female'
 ```
 
 
@@ -108,11 +111,8 @@ No need for a class, just use the `ConstantListEnum` class and define a new enum
 ```yaml
 services:
     enum.member.gender:
-        class: 'Yokai\EnumBundle\ConstantListEnum'
-        public: false
-        tags: ['enum']
+        class: Yokai\EnumBundle\ConstantListEnum
         arguments:
-            - '@enum.constant_extractor'
-            - 'App\\Model\\Person::GENDER_*'
-            - "gender"
+            $constantsPattern: 'App\\Model\\Person::GENDER_*'
+            $name: 'gender'
 ```

--- a/doc/declaring-translated-enum.md
+++ b/doc/declaring-translated-enum.md
@@ -8,6 +8,16 @@ There is a lot of way to create and declare such classes.
 > **Note :** It is pretty much like [declaring classic enums](declaring-enum.md), 
 > but with a dependency to `symfony/translator`.
 
+Services declarations assume that your services files has the following defaults section :
+
+```yaml
+services:
+    _defaults:
+        public: false
+        autowire: true
+        autconfigure: true
+```
+
 
 The classic way
 ---------------
@@ -41,16 +51,11 @@ class GenderEnum extends AbstractTranslatedEnum
 }
 ```
 
-Define an enum service for it.
+Define an enum service for it (optional if you are using the default Symfony services file).
 
 ```yaml
 services:
-    enum.member.gender:
-        class: 'App\Enum\GenderEnum'
-        public: false
-        tags: ['enum']
-        arguments:
-            - "@translator"
+    App\Enum\GenderEnum: ~
 ```
 
 
@@ -84,16 +89,11 @@ class GenderEnum extends AbstractTranslatedEnum
 }
 ```
 
-Define an enum service for it.
+Define an enum service for it (optional if you are using the default Symfony services file).
 
 ```yaml
 services:
-    enum.member.gender:
-        class: 'App\Enum\GenderEnum'
-        public: false
-        tags: ['enum']
-        arguments:
-            - "@translator"
+    App\Enum\GenderEnum: ~
 ```
 
 
@@ -105,14 +105,11 @@ No need for a class, just use the `ConfigurableTranslatedEnum` class and define 
 ```yaml
 services:
     enum.member.gender:
-        class: 'Yokai\EnumBundle\ConfigurableTranslatedEnum'
-        public: false
-        tags: ['enum']
+        class: Yokai\EnumBundle\ConfigurableTranslatedEnum
         arguments:
-            - "@translator"
-            - "enum.gender.%s"
-            - "gender"
-            - ['m', 'f']
+            $transPattern: 'enum.gender.%s'
+            $name: 'gender'
+            $values: ['m', 'f']
 ```
 
 The configurable way extracting constant list
@@ -124,13 +121,9 @@ No need for a class, just use the `ConstantListTranslatedEnum` class and define 
 ```yaml
 services:
     enum.member.gender:
-        class: 'Yokai\EnumBundle\ConstantListTranslatedEnum'
-        public: false
-        tags: ['enum']
+        class: Yokai\EnumBundle\ConstantListTranslatedEnum
         arguments:
-            - '@yokai_enum.constant_extractor'
-            - 'App\\Model\\Person::GENDER_*'
-            - "@translator"
-            - "enum.gender.%s"
-            - "gender"
+            $constantsPattern: 'App\\Model\\Person::GENDER_*'
+            $transPattern: 'enum.gender.%s'
+            $name: 'gender'
 ```

--- a/src/ConstantExtractor.php
+++ b/src/ConstantExtractor.php
@@ -15,18 +15,18 @@ use Yokai\EnumBundle\Exception\CannotExtractConstantsException;
  */
 class ConstantExtractor
 {
-    public function extract(string $pattern): array
+    public static function extract(string $pattern): array
     {
-        [$class, $patternRegex] = $this->explode($pattern);
+        [$class, $patternRegex] = self::explode($pattern);
 
-        return $this->filter(
-            $this->publicConstants($class),
+        return self::filter(
+            self::publicConstants($class),
             $patternRegex,
             $pattern
         );
     }
 
-    private function filter(array $constants, string $regexp, string $pattern): array
+    private static function filter(array $constants, string $regexp, string $pattern): array
     {
         $matchingNames = preg_grep($regexp, array_keys($constants));
 
@@ -37,7 +37,7 @@ class ConstantExtractor
         return array_values(array_intersect_key($constants, array_flip($matchingNames)));
     }
 
-    private function publicConstants(string $class): array
+    private static function publicConstants(string $class): array
     {
         try {
             $constants = (new ReflectionClass($class))->getReflectionConstants();
@@ -61,7 +61,7 @@ class ConstantExtractor
         return $list;
     }
 
-    private function explode(string $pattern): array
+    private static function explode(string $pattern): array
     {
         if (substr_count($pattern, '::') !== 1) {
             throw CannotExtractConstantsException::invalidPattern($pattern);

--- a/src/ConstantListEnum.php
+++ b/src/ConstantListEnum.php
@@ -12,9 +12,9 @@ class ConstantListEnum extends ConfigurableEnum
     /**
      * @inheritDoc
      */
-    public function __construct(ConstantExtractor $extractor, string $constantsPattern, string $name)
+    public function __construct(string $constantsPattern, string $name)
     {
-        $values = $extractor->extract($constantsPattern);
+        $values = ConstantExtractor::extract($constantsPattern);
         parent::__construct($name, array_combine($values, $values));
     }
 }

--- a/src/ConstantListTranslatedEnum.php
+++ b/src/ConstantListTranslatedEnum.php
@@ -15,12 +15,11 @@ class ConstantListTranslatedEnum extends ConfigurableTranslatedEnum
      * @inheritDoc
      */
     public function __construct(
-        ConstantExtractor $extractor,
         string $constantsPattern,
         TranslatorInterface $translator,
         string $transPattern,
         string $name
     ) {
-        parent::__construct($translator, $transPattern, $name, $extractor->extract($constantsPattern));
+        parent::__construct($translator, $transPattern, $name, ConstantExtractor::extract($constantsPattern));
     }
 }

--- a/src/Resources/config/enum.xml
+++ b/src/Resources/config/enum.xml
@@ -7,7 +7,6 @@
     <services>
         <service id="Yokai\EnumBundle\EnumRegistry" alias="yokai_enum.enum_registry"/>
 
-        <service id="yokai_enum.constant_extractor" class="Yokai\EnumBundle\ConstantExtractor" public="false"/>
         <service id="yokai_enum.enum_registry" class="Yokai\EnumBundle\EnumRegistry"/>
         <service id="yokai_enum.abstract_translated_enum" class="Yokai\EnumBundle\AbstractTranslatedEnum" abstract="true">
             <argument type="service" id="translator"/>

--- a/tests/ConstantExtractorTest.php
+++ b/tests/ConstantExtractorTest.php
@@ -11,11 +11,6 @@ use Yokai\EnumBundle\Exception\CannotExtractConstantsException;
  */
 class ConstantExtractorTest extends TestCase
 {
-    public function getExtractor(): ConstantExtractor
-    {
-        return new ConstantExtractor();
-    }
-
     /**
      * @dataProvider malformed
      */
@@ -24,7 +19,7 @@ class ConstantExtractorTest extends TestCase
         $this->expectException(CannotExtractConstantsException::class);
         $this->expectExceptionMessageMatches($exceptionMessage);
 
-        $this->getExtractor()->extract($pattern);
+        ConstantExtractor::extract($pattern);
     }
 
     /**
@@ -35,7 +30,7 @@ class ConstantExtractorTest extends TestCase
         $this->expectException(CannotExtractConstantsException::class);
         $this->expectExceptionMessageMatches($exceptionMessage);
 
-        $this->getExtractor()->extract($pattern);
+        ConstantExtractor::extract($pattern);
     }
 
     /**
@@ -43,7 +38,7 @@ class ConstantExtractorTest extends TestCase
      */
     public function testExtractSuccessful(string $pattern, array $expectedList): void
     {
-        self::assertEquals($expectedList, $this->getExtractor()->extract($pattern));
+        self::assertEquals($expectedList, ConstantExtractor::extract($pattern));
     }
 
     public function empty(): Generator

--- a/tests/ConstantListEnumTest.php
+++ b/tests/ConstantListEnumTest.php
@@ -2,7 +2,6 @@
 
 namespace Yokai\EnumBundle\Tests;
 
-use Yokai\EnumBundle\ConstantExtractor;
 use Yokai\EnumBundle\ConstantListEnum;
 use Yokai\EnumBundle\Tests\Fixtures\Vehicle;
 
@@ -13,7 +12,7 @@ class ConstantListEnumTest extends TestCase
 {
     public function getEnum(string $pattern, string $name): ConstantListEnum
     {
-        return new ConstantListEnum(new ConstantExtractor(), $pattern, $name);
+        return new ConstantListEnum($pattern, $name);
     }
 
     public function testVehicleEnums(): void

--- a/tests/ConstantListTranslatedEnumTest.php
+++ b/tests/ConstantListTranslatedEnumTest.php
@@ -4,7 +4,6 @@ namespace Yokai\EnumBundle\Tests;
 
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Yokai\EnumBundle\ConstantExtractor;
 use Yokai\EnumBundle\ConstantListTranslatedEnum;
 use Yokai\EnumBundle\Tests\Fixtures\Vehicle;
 
@@ -26,7 +25,6 @@ class ConstantListTranslatedEnumTest extends TestCase
     public function getEnum(string $pattern, string $name): ConstantListTranslatedEnum
     {
         return new ConstantListTranslatedEnum(
-            new ConstantExtractor(),
             $pattern,
             $this->translator->reveal(),
             $name.'.%s',


### PR DESCRIPTION
To simplify enum service registration, I choose to present autowired versions
ConstantExtractor was made static, because it has no dependency and is marked as internal as of 3.x
