### PR TITLE
Fix Choice annotation/attribute constructor args changing with Symfony versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,10 @@ jobs:
           - php-version: 8.1
             symfony-version: 4.4.*
           - php-version: 7.2
+            symfony-version: 5.2.*
+          - php-version: 7.2
+            symfony-version: 5.3.*
+          - php-version: 7.2
             symfony-version: 5.4.*
           - php-version: 8.1
             symfony-version: 5.4.*

--- a/src/Validator/Constraints/Enum.php
+++ b/src/Validator/Constraints/Enum.php
@@ -42,23 +42,45 @@ final class Enum extends Choice
             if (\is_string($enum)) {
                 $this->enum = $enum;
             }
-
             // Symfony 5.x Constraints has many constructor arguments for PHP 8.0 Attributes support
-            parent::__construct(
-                null,
-                $callback,
-                $multiple,
-                $strict,
-                $min,
-                $max,
-                $message,
-                $multipleMessage,
-                $minMessage,
-                $maxMessage,
-                $groups,
-                $payload,
-                $options
-            );
+
+            $firstConstructorArg = (new \ReflectionClass(Choice::class))
+                ->getConstructor()->getParameters()[0]->getName();
+            if ($firstConstructorArg === 'choices') {
+                // Prior to Symfony 5.3, first argument of Choice was $choices
+                parent::__construct(
+                    null,
+                    $callback,
+                    $multiple,
+                    $strict,
+                    $min,
+                    $max,
+                    $message,
+                    $multipleMessage,
+                    $minMessage,
+                    $maxMessage,
+                    $groups,
+                    $payload,
+                    $options
+                );
+            } else {
+                // Since Symfony 5.3, first argument of Choice is $options
+                parent::__construct(
+                    $options,
+                    null,
+                    $callback,
+                    $multiple,
+                    $strict,
+                    $min,
+                    $max,
+                    $message,
+                    $multipleMessage,
+                    $minMessage,
+                    $maxMessage,
+                    $groups,
+                    $payload
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Following #52 this PR tries to fix issues with Symfony's `Choice` constructor args order changing between `5.x` versions 