### PR TITLE
Allow Symfony 7.x and bump dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request: null
   push:
     branches:
-      - "4.x"
+      - "5.x"
 
 jobs:
   phpunit:
@@ -14,30 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: '7.1'
-            symfony-version: '4.4.*'
-
-          - php-version: '7.4'
-            symfony-version: '4.4.*'
-          - php-version: '7.4'
-            symfony-version: '5.4.*'
-
-          - php-version: '8.0'
-            symfony-version: '4.4.*'
-          - php-version: '8.0'
-            symfony-version: '5.4.*'
-          - php-version: '8.0'
-            symfony-version: '6.0.*'
-
-          - php-version: '8.1'
-            symfony-version: '5.4.*'
-          - php-version: '8.1'
-            symfony-version: '6.3.*'
-
           - php-version: '8.2'
-            symfony-version: '5.4.*'
-          - php-version: '8.2'
-            symfony-version: '6.3.*'
+            symfony-version: '7.0.*'
+          - php-version: '8.3'
+            symfony-version: '7.1.*'
 
     steps:
       - name: "Checkout"
@@ -75,7 +55,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: xdebug
-          php-version: '8.2'
+          php-version: '8.3'
 
       - name: "Install dependencies with composer"
         run: composer update --no-interaction --no-progress
@@ -101,7 +81,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: xdebug
-          php-version: '8.2'
+          php-version: '8.3'
 
       - name: "Install dependencies with composer"
         run: composer update --no-interaction --no-progress

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,20 @@
         }
     ],
     "require": {
-        "php": "^7.1.3|^8.0",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0"
+        "php": "^8.2",
+        "symfony/framework-bundle": "7.0.*"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.3",
-        "myclabs/php-enum": "^1.7",
-        "phpunit/phpunit": "^7.5|^8.5|^9.5",
-        "sensio/framework-extra-bundle": "^5.5|^6.1",
-        "squizlabs/php_codesniffer": "^3.5",
-        "symfony/form": "^4.4|^5.0|^6.0",
-        "symfony/translation": "^4.4|^5.0|^6.0",
-        "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-        "symfony/validator": "^4.4|^5.0|^6.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0",
+        "doctrine/annotations": "^1.14",
+        "myclabs/php-enum": "^1.8",
+        "phpunit/phpunit": "^9.6",
+        "squizlabs/php_codesniffer": "^3.10",
+        "symfony/form": "^7.0",
+        "symfony/http-kernel": "^7.0",
+        "symfony/translation": "^7.0",
+        "symfony/twig-bundle": "^7.0",
+        "symfony/validator": "^7.0",
+        "symfony/yaml": "^7.0",
         "twig/twig": "^2.0|^3.0"
     },
     "suggest": {
@@ -46,6 +46,7 @@
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
+            "dev-5.x": "5.x-dev",
             "dev-4.x": "4.x-dev",
             "dev-3.x": "3.x-dev",
             "dev-2.x": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "symfony/framework-bundle": "7.0.*"
+        "symfony/framework-bundle": "^7.0"
     },
     "require-dev": {
         "doctrine/annotations": "^1.14",

--- a/tests/Integration/src/Kernel.php
+++ b/tests/Integration/src/Kernel.php
@@ -46,7 +46,7 @@ final class Kernel extends BaseKernel
     /**
      * @inheritDoc
      */
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(
             new class implements CompilerPassInterface {


### PR DESCRIPTION
- :stop_sign: Drop support for PHP < 8.2
- :stop_sign: Drop support for Symfony < 7.0
- :new: Add support for Symfony >= 7.0